### PR TITLE
Fixed getting the file name: don't try to remove the type if there is none

### DIFF
--- a/plugins/net.bioclipse.myexperiment/src/net/bioclipse/myexperiment/business/MyExperimentManager.java
+++ b/plugins/net.bioclipse.myexperiment/src/net/bioclipse/myexperiment/business/MyExperimentManager.java
@@ -161,6 +161,7 @@ public class MyExperimentManager implements IBioclipseManager {
     }
     
     private String removeType(String filename) {
+    	if (!filename.contains("^^")) return filename;
         StringBuffer result = new StringBuffer();
         boolean typeSeparatorFound = false;
         for (int i=filename.length()-1; i>=0; i--) {


### PR DESCRIPTION
Arvid,

the MyExperiment SPARQL end point is back online, and things were mostly working, except for one method, which failed because the file name was no longer properly corrected, due to a change in the BC RDF stuff.

Please apply. Also, if possible, please get the test suite for bioclipse.social on Hudson.

Egon
