### PR TITLE
Make sure that the method removeType returns a filename

### DIFF
--- a/plugins/net.bioclipse.myexperiment/src/net/bioclipse/myexperiment/business/MyExperimentManager.java
+++ b/plugins/net.bioclipse.myexperiment/src/net/bioclipse/myexperiment/business/MyExperimentManager.java
@@ -171,7 +171,11 @@ public class MyExperimentManager implements IBioclipseManager {
                 typeSeparatorFound = true;
             }
         }
-        return result.reverse().toString();
+        
+        if (!typeSeparatorFound)
+            return filename;
+        else
+            return result.reverse().toString();
     }
 
     private IProject getProjectDirectory(IProgressMonitor monitor)


### PR DESCRIPTION
This solves bug 3498. The problem turned out to be that a method ( removeType(String) ) that removes the char ^ from the file name did not returned a file name if it the filename didn't contained that char. With this commit it returns the filename as it was sent in if it don't contain a ^, if the filename do contains ^ those are removed from the filename.
