### PR TITLE
Fix typo in feature description ({w->s}haring)

### DIFF
--- a/features/net.bioclipse.social_feature/feature.xml
+++ b/features/net.bioclipse.social_feature/feature.xml
@@ -7,7 +7,7 @@
       plugin="net.bioclipse.myexperiment">
 
    <description>
-      Linking Bioclipse to the Social Web with support for e.g. MyExperiment (www.myexperiment.org) for wharing workflows and scripts.
+      Linking Bioclipse to the Social Web with support for e.g. MyExperiment (www.myexperiment.org) for sharing workflows and scripts.
    </description>
 
    <copyright>


### PR DESCRIPTION
Seems like a somewhat embarrassing typo (wharing instead of sharing):

![selection_448](https://user-images.githubusercontent.com/125003/32222052-0bd2bcee-be38-11e7-8e8f-6f8ce4c84d06.png)
